### PR TITLE
Remove Admin Events UI and event multiplier logic

### DIFF
--- a/app.js
+++ b/app.js
@@ -227,13 +227,6 @@
     fish: { name: 'Fish Minigame', cost: 300, reward: 900, winChance: 0.38 }
   };
 
-  var EVENTS = {
-    NONE: { name: 'None', mult: 1 },
-    RAIN: { name: 'Rain', mult: 1.5 },
-    THUNDER: { name: 'Thunder', mult: 2 },
-    DISCO: { name: 'Disco', mult: 2.4 }
-  };
-
   var COINS = {
     JOHAN: { name: 'Johan coin', vol: 11 },
     CHATGPT: { name: 'ChatcoinGPT', vol: 8 },
@@ -250,7 +243,6 @@
     musicOwned: [],
     bgOwned: ['dark'],
     activeBg: 'dark',
-    activeEvent: 'NONE',
     activeCoin: 'JOHAN',
     coinPrice: { JOHAN: 120, CHATGPT: 90, KIRB: 200 },
     coinWallet: { JOHAN: 0, CHATGPT: 0, KIRB: 0 }
@@ -285,7 +277,7 @@
     }
     total *= currentSkin().mult;
     total *= (1 + state.rebirths * 0.25);
-    total *= (EVENTS[state.activeEvent] || EVENTS.NONE).mult;
+    total *= 1;
     return total;
   }
 
@@ -349,7 +341,6 @@
     el('tims').textContent = Math.floor(state.tims);
     el('cps').textContent = cps().toFixed(1);
     el('rebirths').textContent = state.rebirths;
-    el('eventText').textContent = (EVENTS[state.activeEvent] || EVENTS.NONE).name;
     el('coinPrice').textContent = state.coinPrice[coinId].toFixed(1);
     el('coinWallet').textContent = state.coinWallet[coinId].toFixed(2);
     el('timImage').src = currentSkin().file;

--- a/index.html
+++ b/index.html
@@ -23,7 +23,6 @@
         <div><span>Tims</span><b id="tims">0</b></div>
         <div><span>CPS</span><b id="cps">0</b></div>
         <div><span>Rebirths</span><b id="rebirths">0</b></div>
-        <div><span>Event</span><b id="eventText">None</b></div>
       </header>
 
       <section class="card click-area">
@@ -69,12 +68,6 @@
           <button id="buyCoinBtn">Buy 1 coin</button>
           <button id="sellCoinBtn">Sell 1 coin</button>
         </div>
-      </section>
-
-      <section class="card">
-        <h2>Admin Events</h2>
-        <input id="adminCodeInput" placeholder="Event code (RAIN/THUNDER/DISCO/CLEAR)">
-        <button id="setEventBtn">Set Event</button>
       </section>
 
       <section class="card">

--- a/script.js
+++ b/script.js
@@ -228,13 +228,6 @@
     fish: { name: 'Fish Minigame', cost: 300, reward: 900, winChance: 0.38 }
   };
 
-  var EVENTS = {
-    NONE: { name: 'None', mult: 1 },
-    RAIN: { name: 'Rain', mult: 1.5 },
-    THUNDER: { name: 'Thunder', mult: 2 },
-    DISCO: { name: 'Disco', mult: 2.4 }
-  };
-
   var COINS = {
     JOHAN: { name: 'Johan coin', vol: 11 },
     CHATGPT: { name: 'ChatcoinGPT', vol: 8 },
@@ -251,7 +244,6 @@
     musicOwned: [],
     bgOwned: ['dark'],
     activeBg: 'dark',
-    activeEvent: 'NONE',
     activeCoin: 'JOHAN',
     coinPrice: { JOHAN: 120, CHATGPT: 90, KIRB: 200 },
     coinWallet: { JOHAN: 0, CHATGPT: 0, KIRB: 0 }
@@ -286,7 +278,7 @@
     }
     total *= currentSkin().mult;
     total *= (1 + state.rebirths * 0.25);
-    total *= (EVENTS[state.activeEvent] || EVENTS.NONE).mult;
+    total *= 1;
     return total;
   }
 
@@ -350,7 +342,6 @@
     el('tims').textContent = Math.floor(state.tims);
     el('cps').textContent = cps().toFixed(1);
     el('rebirths').textContent = state.rebirths;
-    el('eventText').textContent = (EVENTS[state.activeEvent] || EVENTS.NONE).name;
     el('coinPrice').textContent = state.coinPrice[coinId].toFixed(1);
     el('coinWallet').textContent = state.coinWallet[coinId].toFixed(2);
     el('timImage').src = currentSkin().file;


### PR DESCRIPTION
### Motivation
- Remove the Admin Events UI and server-admin event mutation pathway to simplify the UI and remove an admin-only control surface.
- Stop displaying event state in the stats and eliminate event-based CPS multipliers so stat rendering is deterministic.
- Keep the game logic aligned across bundled runtime files (`script.js` and `app.js`) to avoid divergence.

### Description
- Deleted the Event stat row and the entire Admin Events card (`#adminCodeInput`, `#setEventBtn`) from `index.html`.
- Removed the `EVENTS` object and cleared the `activeEvent` field from `defaultState` in both `script.js` and `app.js`.
- Pinned the event multiplier to a constant `1` in the CPS calculation by replacing `(EVENTS[state.activeEvent] || EVENTS.NONE).mult` with `1` in both runtime files.
- Removed rendering updates for the event text (no more `eventText` writes) and verified there were no admin-specific CSS selectors to remove.

### Testing
- Searched for remaining admin references with `rg -n "adminCodeInput|setEventBtn|eventText|activeEvent|EVENTS|Admin Events"` and found no matches.
- Syntax-checked the updated JS with `node --check script.js && node --check app.js`, which completed successfully.
- Launched a local static server (`python -m http.server 4173`) and captured a Playwright screenshot to visually validate the UI changes, which produced the expected UI without admin event controls.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69934eabcce483308260f376c7ea5e25)