### PR TITLE
Validate and dedupe skinCandidates; probe verified skin paths before fallback

### DIFF
--- a/app.js
+++ b/app.js
@@ -90,17 +90,17 @@
   var SKINS = [];
   var skinCandidates = [
     'assets/skins/default.png',
-    'assets/skins/Gold.png',
     'assets/skins/AMONG_US.png',
     'assets/skins/Assasin_Tim.png',
     'assets/skins/B.T.S._Tim.png',
     'assets/skins/Baby_Tim.png',
     'assets/skins/Blooket_Tim.png',
     'assets/skins/Blueprint_Tim.png',
-    'assets/skins/G.O.A.T..jpg',
+    'assets/skins/Gold.png',
     'assets/skins/Hologram_Tim.png',
     'assets/skins/Inverted_Tim.png',
     'assets/skins/JOHAN.png',
+    'assets/skins/Johnny_Tims.png',
     'assets/skins/Joker_Of_Tims.png',
     'assets/skins/Kartonnen_Doos.png',
     'assets/skins/Marble_Tim.png',
@@ -121,9 +121,65 @@
     'assets/skins/Tim_Of_War.png',
     'assets/skins/TimaCola.png',
     'assets/skins/TimoBama.png',
+    'assets/skins/Timpy.png',
     'assets/skins/Timtoday.png',
     'assets/skins/Timton_G_Timton.png'
   ];
+
+  var knownSkinFiles = {
+    'assets/skins/default.png': true,
+    'assets/skins/AMONG_US.png': true,
+    'assets/skins/Assasin_Tim.png': true,
+    'assets/skins/B.T.S._Tim.png': true,
+    'assets/skins/Baby_Tim.png': true,
+    'assets/skins/Blooket_Tim.png': true,
+    'assets/skins/Blueprint_Tim.png': true,
+    'assets/skins/Gold.png': true,
+    'assets/skins/Hologram_Tim.png': true,
+    'assets/skins/Inverted_Tim.png': true,
+    'assets/skins/JOHAN.png': true,
+    'assets/skins/Johnny_Tims.png': true,
+    'assets/skins/Joker_Of_Tims.png': true,
+    'assets/skins/Kartonnen_Doos.png': true,
+    'assets/skins/Marble_Tim.png': true,
+    'assets/skins/Mr._Timmah.png': true,
+    'assets/skins/Neutronen_Tim.png': true,
+    'assets/skins/Nyan_Tim.png': true,
+    'assets/skins/Plague_Serpent.png': true,
+    'assets/skins/Planet_Tim.gif': true,
+    'assets/skins/Pufferfish_Tim.png': true,
+    'assets/skins/Rat_Wizard_Tim.png': true,
+    'assets/skins/Scout_Tim.png': true,
+    'assets/skins/Solar_Tim.png': true,
+    'assets/skins/TIM.png': true,
+    'assets/skins/Terminal_Tim.png': true,
+    'assets/skins/Tim_Driving_In_Car_Right_After_A_Beer.png': true,
+    'assets/skins/Tim_Missprinttttttttt.png': true,
+    'assets/skins/Tim_Of_War.png': true,
+    'assets/skins/TimaCola.png': true,
+    'assets/skins/Timpy.png': true,
+    'assets/skins/TimTim.png': true,
+    'assets/skins/Timtoday.png': true,
+    'assets/skins/TimoBama.png': true,
+    'assets/skins/Timton_G_Timton.png': true
+  };
+
+  function prepareSkinCandidates(candidates) {
+    var validExt = /\.(png|gif)$/i;
+    var seen = {};
+    var normalized = [];
+    for (var i = 0; i < candidates.length; i++) {
+      var candidate = (candidates[i] || '').trim();
+      if (!candidate || seen[candidate]) continue;
+      seen[candidate] = true;
+      if (!validExt.test(candidate)) continue;
+      if (!knownSkinFiles[candidate]) continue;
+      normalized.push(candidate);
+    }
+    return normalized;
+  }
+
+  var validatedSkinCandidates = prepareSkinCandidates(skinCandidates);
 
   var skinFallbackPool = [
     'assets/skins/default.png',
@@ -139,7 +195,7 @@
 
   function loadSkinCatalog(done) {
     var entries = [];
-    var remaining = skinCandidates.length;
+    var remaining = validatedSkinCandidates.length;
     var completed = false;
 
     function finalize() {
@@ -204,8 +260,8 @@
       return;
     }
 
-    for (var i = 0; i < skinCandidates.length; i++) {
-      resolveCandidate(skinCandidates[i], i);
+    for (var i = 0; i < validatedSkinCandidates.length; i++) {
+      resolveCandidate(validatedSkinCandidates[i], i);
     }
 
     setTimeout(finalize, 2200);

--- a/script.js
+++ b/script.js
@@ -90,14 +90,13 @@
   var SKINS = [];
   var skinCandidates = [
     'assets/skins/default.png',
-    'assets/skins/Gold.png',
     'assets/skins/AMONG_US.png',
     'assets/skins/Assasin_Tim.png',
     'assets/skins/B.T.S._Tim.png',
     'assets/skins/Baby_Tim.png',
     'assets/skins/Blooket_Tim.png',
     'assets/skins/Blueprint_Tim.png',
-    'assets/skins/G.O.A.T..jpg',
+    'assets/skins/Gold.png',
     'assets/skins/Hologram_Tim.png',
     'assets/skins/Inverted_Tim.png',
     'assets/skins/JOHAN.png',
@@ -127,6 +126,61 @@
     'assets/skins/Timton_G_Timton.png'
   ];
 
+  var knownSkinFiles = {
+    'assets/skins/default.png': true,
+    'assets/skins/AMONG_US.png': true,
+    'assets/skins/Assasin_Tim.png': true,
+    'assets/skins/B.T.S._Tim.png': true,
+    'assets/skins/Baby_Tim.png': true,
+    'assets/skins/Blooket_Tim.png': true,
+    'assets/skins/Blueprint_Tim.png': true,
+    'assets/skins/Gold.png': true,
+    'assets/skins/Hologram_Tim.png': true,
+    'assets/skins/Inverted_Tim.png': true,
+    'assets/skins/JOHAN.png': true,
+    'assets/skins/Johnny_Tims.png': true,
+    'assets/skins/Joker_Of_Tims.png': true,
+    'assets/skins/Kartonnen_Doos.png': true,
+    'assets/skins/Marble_Tim.png': true,
+    'assets/skins/Mr._Timmah.png': true,
+    'assets/skins/Neutronen_Tim.png': true,
+    'assets/skins/Nyan_Tim.png': true,
+    'assets/skins/Plague_Serpent.png': true,
+    'assets/skins/Planet_Tim.gif': true,
+    'assets/skins/Pufferfish_Tim.png': true,
+    'assets/skins/Rat_Wizard_Tim.png': true,
+    'assets/skins/Scout_Tim.png': true,
+    'assets/skins/Solar_Tim.png': true,
+    'assets/skins/TIM.png': true,
+    'assets/skins/Terminal_Tim.png': true,
+    'assets/skins/Tim_Driving_In_Car_Right_After_A_Beer.png': true,
+    'assets/skins/Tim_Missprinttttttttt.png': true,
+    'assets/skins/Tim_Of_War.png': true,
+    'assets/skins/TimaCola.png': true,
+    'assets/skins/Timpy.png': true,
+    'assets/skins/TimTim.png': true,
+    'assets/skins/Timtoday.png': true,
+    'assets/skins/TimoBama.png': true,
+    'assets/skins/Timton_G_Timton.png': true
+  };
+
+  function prepareSkinCandidates(candidates) {
+    var validExt = /\.(png|gif)$/i;
+    var seen = {};
+    var normalized = [];
+    for (var i = 0; i < candidates.length; i++) {
+      var candidate = (candidates[i] || '').trim();
+      if (!candidate || seen[candidate]) continue;
+      seen[candidate] = true;
+      if (!validExt.test(candidate)) continue;
+      if (!knownSkinFiles[candidate]) continue;
+      normalized.push(candidate);
+    }
+    return normalized;
+  }
+
+  var validatedSkinCandidates = prepareSkinCandidates(skinCandidates);
+
   var skinFallbackPool = [
     'assets/skins/default.png',
   ];
@@ -141,7 +195,7 @@
 
   function loadSkinCatalog(done) {
     var entries = [];
-    var remaining = skinCandidates.length;
+    var remaining = validatedSkinCandidates.length;
     var completed = false;
 
     function finalize() {
@@ -206,8 +260,8 @@
       return;
     }
 
-    for (var i = 0; i < skinCandidates.length; i++) {
-      resolveCandidate(skinCandidates[i], i);
+    for (var i = 0; i < validatedSkinCandidates.length; i++) {
+      resolveCandidate(validatedSkinCandidates[i], i);
     }
 
     setTimeout(finalize, 2200);


### PR DESCRIPTION
### Motivation
- Reduce console/image-load errors by avoiding probing malformed or non-existent skin paths and ensure listed candidates match real files in `assets/skins`.
- Ensure `skinCandidates` entries use valid image extensions (`.png`/`.gif`) and remove/replace incorrect entries (notably the stray `.jpg` and duplicate/misaligned entries).

### Description
- Aligned and cleaned the `skinCandidates` arrays in both `script.js` and `app.js` to only include valid `.png`/`.gif` paths that exist in `assets/skins` and removed the incorrect `.jpg` entry.
- Added a `knownSkinFiles` lookup and a `prepareSkinCandidates` preprocessing function that trims, de-duplicates, enforces extension validation and filters candidates against `knownSkinFiles`.
- Introduced `validatedSkinCandidates` and switched the catalog probing to iterate over it first while preserving the existing `skinFallbackPool` behavior for missing images.
- Kept original fallback logic intact so a fallback skin is still used when a candidate fails to load, but avoid unnecessary probes against invalid candidates.

### Testing
- Ran `node --check script.js` which completed successfully.
- Ran `node --check app.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69934ecd13a8833081925b67fd81fb72)