### PR TITLE
Fix cookie consent popup boot flow syntax error

### DIFF
--- a/script.js
+++ b/script.js
@@ -753,7 +753,7 @@
   function boot() {
     applyBackground();
     applyActiveSkin();
-    document.body.classList.add('cookie-lock');
+    var popup = el('cookiePopup');
 
     function openIfNamed() {
       if (!state.name) return;
@@ -763,18 +763,34 @@
       renderAll();
     }
 
-    el('acceptCookiesBtn').onclick = function () {
-      saveAllowed = true;
-      el('cookiePopup').classList.add('hidden');
-      document.body.classList.remove('cookie-lock');
-      loadLocal();
-      initFirebaseAuth().then(function () {
+    function continueAfterConsent(consent) {
+      if (consent === 'accepted') {
+        saveAllowed = true;
+        popup.classList.add('hidden');
+        document.body.classList.remove('cookie-lock');
+        loadLocal();
+        initFirebaseAuth().then(function () {
+          applyActiveSkin();
+          openIfNamed();
+          renderAll();
+        });
+        return;
+      }
+
+      if (consent === 'declined') {
+        saveAllowed = false;
+        uid = null;
+        popup.classList.add('hidden');
+        document.body.classList.remove('cookie-lock');
+        setStatus('Saving declined. Nothing will be saved (risk accepted).');
         applyActiveSkin();
         openIfNamed();
         renderAll();
         return;
       }
 
+      saveAllowed = false;
+      uid = null;
       document.body.classList.add('cookie-lock');
       popup.classList.remove('hidden');
       setStatus('Please accept or decline saving cookies.');
@@ -786,14 +802,8 @@
     };
 
     el('declineCookiesBtn').onclick = function () {
-      saveAllowed = false;
-      uid = null;
-      el('cookiePopup').classList.add('hidden');
-      document.body.classList.remove('cookie-lock');
-      setStatus('Saving declined. Nothing will be saved (risk accepted).');
-      applyActiveSkin();
-      openIfNamed();
-      renderAll();
+      storeConsent('declined');
+      continueAfterConsent('declined');
     };
 
     continueAfterConsent(readConsent());


### PR DESCRIPTION
### Motivation
- A broken inline `acceptCookiesBtn` handler caused a `SyntaxError: missing ) after argument list` and prevented the script from loading and the cookie popup from being dismissed.
- Centralize consent handling to reliably handle `accepted`, `declined`, and unset states and to avoid duplicated/fragile logic.

### Description
- Replace the broken inline accept handler with a new helper `continueAfterConsent(consent)` that implements the `accepted`, `declined`, and prompt behaviors.
- Cache the popup element via `var popup = el('cookiePopup')` and use it in the shared flow.
- Update `acceptCookiesBtn` and `declineCookiesBtn` handlers to call `storeConsent('accepted'|'declined')` and route through `continueAfterConsent` for consistent behavior.

### Testing
- Ran `node --check script.js` and it completed successfully.
- Served the site with `python -m http.server 8000` and used Playwright to load `http://127.0.0.1:8000/index.html` and capture a screenshot (`artifacts/cookie-popup-fix.png`), which completed successfully.
- The temporary HTTP server process was terminated as part of validation and the test steps succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69938ea9e8248330ad3da4a3b41b064d)