### PR TITLE
Show rebirth price and make UI 50% transparent

### DIFF
--- a/script.js
+++ b/script.js
@@ -337,6 +337,10 @@
     return total;
   }
 
+  function rebirthCost() {
+    return 1000000 * Math.pow(3, state.rebirths);
+  }
+
   function saveLocal() {
     if (!saveAllowed) return;
     try {
@@ -469,10 +473,12 @@
   // ---------- Render ----------
   function updateStats() {
     var coinId = state.activeCoin;
+    var needed = rebirthCost();
     el('playerName').textContent = state.name;
     el('tims').textContent = Math.floor(state.tims);
     el('cps').textContent = cps().toFixed(1);
     el('rebirths').textContent = state.rebirths;
+    el('rebirthBtn').textContent = 'Rebirth (' + Math.floor(needed) + ')';
     el('coinPrice').textContent = state.coinPrice[coinId].toFixed(1);
     el('coinWallet').textContent = state.coinWallet[coinId].toFixed(2);
   }
@@ -658,17 +664,7 @@
   };
 
   el('rebirthBtn').onclick = function () {
-    var needed = 1
-    if (state.tims < needed) return;
-    state.tims = 0;
-    state.upgrades = {};
-    state.rebirths += 1;
-    saveNow();
-    renderAll();
-  };
-
-  el('rebirthBtn').onclick = function () {
-    var needed = 1000000 * Math.pow(3, state.rebirths);
+    var needed = rebirthCost();
     if (state.tims < needed) return;
     state.tims = 0;
     state.upgrades = {};

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 :root {
   --bg: #0b1020;
-  --card: #141c31;
-  --line: #2b3b65;
+  --card: rgba(20, 28, 49, 0.5);
+  --line: rgba(43, 59, 101, 0.5);
   --text: #edf2ff;
   --muted: #a9b9e8;
   --accent: #6fa2ff;
@@ -67,7 +67,7 @@ input, button, select {
   padding: 10px;
   border-radius: 8px;
   border: 1px solid var(--line);
-  background: #0f1730;
+  background: rgba(15, 23, 48, 0.5);
   color: var(--text);
   margin: 6px 0;
 }


### PR DESCRIPTION
### Motivation
- Make the rebirth requirement visible in the UI so players can see the current cost before attempting a rebirth. 
- Centralize the rebirth cost calculation to avoid duplication and ensure consistency between display and purchase logic. 
- Adjust the visual design to a semi-transparent look so cards and controls appear 50% transparent for a lighter UI feel.

### Description
- Added a `rebirthCost()` helper that returns `1000000 * Math.pow(3, state.rebirths)` and used it for the rebirth purchase check. 
- Updated `updateStats()` to set the rebirth button label to `Rebirth (<cost>)` using `rebirthCost()` so the cost is shown live. 
- Removed the duplicate/obsolete rebirth click handler so only the intended rebirth flow remains. 
- Switched theme variables and form surface colors to semi-transparent values by changing `--card` and `--line` to `rgba(...)` with `0.5` alpha and inputs/buttons background to `rgba(...,0.5)` in `style.css`.

### Testing
- Ran `node --check script.js` to ensure the script parses and it succeeded. 
- Served the site with `python3 -m http.server 4173` and used a headless Playwright script to load `http://127.0.0.1:4173/index.html`, accept cookies, enter a name and capture a screenshot, which completed successfully. 
- Verified the app updates the rebirth button label and that clicks respect the centralized `rebirthCost()` during the browser run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69942ca80e6c833088ffa09cb82d0a3a)