### PR TITLE
Fix skins loading and add scrollbar to skins shop

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,6 @@
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-database-compat.js"></script>
-  <script src="script.js?v=20260214i"></script>
+  <script src="script.js?v=20260217a"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -98,6 +98,7 @@
     'assets/skins/Blooket_Tim.png',
     'assets/skins/Blueprint_Tim.png',
     'assets/skins/Gold.png',
+    'assets/skins/G.O.A.T..jpg',
     'assets/skins/Hologram_Tim.png',
     'assets/skins/Inverted_Tim.png',
     'assets/skins/JOHAN.png',
@@ -129,46 +130,8 @@
     'assets/skins/Timton_G_Timton.png'
   ];
 
-  var knownSkinFiles = {
-    'assets/skins/default.png': true,
-    'assets/skins/AMONG_US.png': true,
-    'assets/skins/Assasin_Tim.png': true,
-    'assets/skins/B.T.S._Tim.png': true,
-    'assets/skins/Baby_Tim.png': true,
-    'assets/skins/Blooket_Tim.png': true,
-    'assets/skins/Blueprint_Tim.png': true,
-    'assets/skins/Gold.png': true,
-    'assets/skins/Hologram_Tim.png': true,
-    'assets/skins/Inverted_Tim.png': true,
-    'assets/skins/JOHAN.png': true,
-    'assets/skins/Johnny_Tims.png': true,
-    'assets/skins/Joker_Of_Tims.png': true,
-    'assets/skins/Kartonnen_Doos.png': true,
-    'assets/skins/Marble_Tim.png': true,
-    'assets/skins/Mr._Timmah.png': true,
-    'assets/skins/Neutronen_Tim.png': true,
-    'assets/skins/Nyan_Tim.png': true,
-    'assets/skins/Plague_Serpent.png': true,
-    'assets/skins/Planet_Tim.gif': true,
-    'assets/skins/Pufferfish_Tim.png': true,
-    'assets/skins/Rat_Wizard_Tim.png': true,
-    'assets/skins/Scout_Tim.png': true,
-    'assets/skins/Solar_Tim.png': true,
-    'assets/skins/TIM.png': true,
-    'assets/skins/Terminal_Tim.png': true,
-    'assets/skins/Tim_Driving_In_Car_Right_After_A_Beer.png': true,
-    'assets/skins/Tim_Missprinttttttttt.png': true,
-    'assets/skins/Tim_Of_War.png': true,
-    'assets/skins/TimaCola.png': true,
-    'assets/skins/Timpy.png': true,
-    'assets/skins/TimTim.png': true,
-    'assets/skins/Timtoday.png': true,
-    'assets/skins/TimoBama.png': true,
-    'assets/skins/Timton_G_Timton.png': true
-  };
-
   function prepareSkinCandidates(candidates) {
-    var validExt = /\.(png|gif)$/i;
+    var validExt = /\.(png|gif|jpe?g|webp)$/i;
     var seen = {};
     var normalized = [];
     for (var i = 0; i < candidates.length; i++) {
@@ -176,7 +139,6 @@
       if (!candidate || seen[candidate]) continue;
       seen[candidate] = true;
       if (!validExt.test(candidate)) continue;
-      if (!knownSkinFiles[candidate]) continue;
       normalized.push(candidate);
     }
     return normalized;

--- a/style.css
+++ b/style.css
@@ -125,6 +125,12 @@ body.bg-cover {
   padding-right: 4px;
 }
 
+#skinShop {
+  max-height: 340px;
+  overflow: auto;
+  padding-right: 4px;
+}
+
 .upgrade-item {
   display: flex;
   align-items: center;


### PR DESCRIPTION
### Motivation
- Skins added to `assets/skins/` were not appearing because the code used a hardcoded allowlist and only accepted a narrow set of file extensions. 
- The skins shop lacked a scrollable container like the upgrades area, causing long skin lists to overflow the layout. 

### Description
- Removed the restrictive `knownSkinFiles` allowlist so `skinCandidates` are accepted if they are unique and match supported extensions. 
- Expanded the allowed skin filename extensions in `prepareSkinCandidates` to `png|gif|jpg|jpeg|webp` by updating the regex to `\.(png|gif|jpe?g|webp)$` in `script.js`. 
- Added `assets/skins/G.O.A.T..jpg` to the `skinCandidates` list so the new asset is included in the catalog. 
- Added a scrollable container for the skins shop by adding `#skinShop { max-height: 340px; overflow: auto; padding-right: 4px; }` in `style.css`. 
- Bumped the `script.js` cache-buster query parameter in `index.html` so browsers will fetch the updated script. 

### Testing
- Ran `node --check script.js` to validate JS syntax and it succeeded. 
- Started a dev server with `python -m http.server 4173` to exercise the UI and the server started successfully, but an automated Playwright screenshot test failed because the Chromium browser crashed (SIGSEGV) in this environment, so visual end-to-end verification could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69947cc770288330b1a6084eb1f82f06)