### PR TITLE
Show multiplier in stats and allow renaming after login

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,10 @@
       <button id="googleLoginBtn">Login with Google</button>
       <button id="guestLoginBtn">Continue as Guest</button>
       <button id="logoutBtn" class="danger hidden">Logout</button>
+      <div id="renamePanel" class="rename-controls hidden">
+        <input id="renameInput" placeholder="New ingame name">
+        <button id="renameBtn">Change name</button>
+      </div>
       <p id="authStatus" class="status"></p>
     </section>
 
@@ -31,6 +35,7 @@
         <div><span>Player</span><b id="playerName">-</b></div>
         <div><span>Tims</span><b id="tims">0</b></div>
         <div><span>CPS</span><b id="cps">0</b></div>
+        <div><span>Multi</span><b id="multi">x1.00</b></div>
         <div><span>Rebirths</span><b id="rebirths">0</b></div>
       </header>
 

--- a/script.js
+++ b/script.js
@@ -386,18 +386,26 @@
 
   function cps() {
     var total = 0;
-    var multiplier = 1;
     for (var i = 0; i < UPGRADES.length; i++) {
       var up = UPGRADES[i];
       var owned = state.upgrades[up.id] || 0;
       total += owned * (up.add || 0);
-      if (up.mult) multiplier *= Math.pow(up.mult, owned);
     }
-    total *= multiplier;
-    total *= currentSkin().mult;
-    total *= (1 + state.rebirths * 0.25);
+    total *= totalMultiplier();
     total *= 1;
     return total;
+  }
+
+  function totalMultiplier() {
+    var multiplier = 1;
+    for (var i = 0; i < UPGRADES.length; i++) {
+      var up = UPGRADES[i];
+      var owned = state.upgrades[up.id] || 0;
+      if (up.mult) multiplier *= Math.pow(up.mult, owned);
+    }
+    multiplier *= currentSkin().mult;
+    multiplier *= (1 + state.rebirths * 0.25);
+    return multiplier;
   }
 
   function rebirthCost() {
@@ -598,6 +606,7 @@
     el('playerName').textContent = state.name;
     el('tims').textContent = Math.floor(state.tims);
     el('cps').textContent = cps().toFixed(1);
+    el('multi').textContent = 'x' + totalMultiplier().toFixed(2);
     el('rebirths').textContent = state.rebirths;
     el('rebirthBtn').textContent = 'Rebirth (' + Math.floor(needed) + ')';
     el('coinPrice').textContent = state.coinPrice[coinId].toFixed(1);
@@ -900,12 +909,16 @@
   function updateAuthUi(user) {
     var authStatus = el('authStatus');
     var logoutBtn = el('logoutBtn');
+    var renamePanel = el('renamePanel');
     if (user) {
       authStatus.textContent = 'Logged in as ' + (user.displayName || user.email || 'Guest');
       logoutBtn.classList.remove('hidden');
+      renamePanel.classList.remove('hidden');
+      el('renameInput').value = state.name || '';
     } else {
       authStatus.textContent = 'Not logged in. Use Google or continue as guest.';
       logoutBtn.classList.add('hidden');
+      renamePanel.classList.add('hidden');
     }
   }
 
@@ -935,6 +948,15 @@
         saveLocal();
         renderAll();
       });
+    };
+
+    el('renameBtn').onclick = function () {
+      var newName = el('renameInput').value.trim();
+      if (!newName) return;
+      state.name = newName;
+      el('nameInput').value = newName;
+      saveNow(true);
+      renderAll();
     };
   }
 

--- a/style.css
+++ b/style.css
@@ -242,3 +242,20 @@ body.cookie-lock { overflow: hidden; }
 #authPanel button {
   max-width: 360px;
 }
+
+.rename-controls {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.rename-controls input,
+.rename-controls button {
+  margin: 0;
+}
+
+.rename-controls button {
+  width: auto;
+  min-width: 140px;
+}


### PR DESCRIPTION
### Motivation
- Make the player's total multiplier visible in the main stats so its effect on CPS is clear.
- Centralize multiplier logic so it can be displayed and reused consistently.
- Allow players to change their in‑game name after authenticating so names can be corrected/updated without losing progress.

### Description
- Added a `Multi` stat element to the game stats header (`index.html`) to display the current total multiplier. 
- Extracted multiplier computation into a new `totalMultiplier()` helper and updated `cps()` to use it so multiplier math is centralized (`script.js`).
- Added rename controls to the auth panel (`renameInput` + `renameBtn`) that are shown only when a user is logged in and prefilled with the current name, and wired the rename action to update state and call `saveNow(true)` (`index.html`, `script.js`).
- Added compact styling for the rename controls (`.rename-controls`) in `style.css` so the input and button are aligned inside the auth card.

### Testing
- `node --check script.js` ran successfully to validate JavaScript syntax. 
- Launched a local HTTP server (`python -m http.server 4173`) and loaded the app for visual verification, which succeeded. 
- Captured a Playwright screenshot of the updated UI to confirm the new Multi stat and rename controls rendered as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995cc8ec0b483309c1fb2600481e826)