### PR TITLE
Guard skin multiplier when skin catalog is not ready

### DIFF
--- a/script.js
+++ b/script.js
@@ -416,10 +416,20 @@
   }
 
   function currentSkin() {
+    var fallbackSkin = {
+      id: 'skin_1',
+      name: 'Default',
+      file: skinFallbackPool[0] || 'assets/skins/default.png',
+      mult: 1,
+      cost: 0
+    };
+
+    if (!SKINS || SKINS.length === 0) return fallbackSkin;
+
     for (var i = 0; i < SKINS.length; i++) {
       if (SKINS[i].id === state.activeSkin) return SKINS[i];
     }
-    return SKINS[0];
+    return SKINS[0] || fallbackSkin;
   }
 
   function cps() {


### PR DESCRIPTION
### Motivation
- Fix a runtime crash where `totalMultiplier()` attempted to read `.mult` from `undefined` because `currentSkin()` could return no skin while the skin catalog was still loading. 
- Ensure the UI tick/update path is safe before the asynchronous skin catalog is populated.

### Description
- Added a safe `fallbackSkin` object (with `mult: 1`) inside `currentSkin()` and return it when `SKINS` is missing or empty. 
- Kept existing selection logic to prefer `state.activeSkin` and then `SKINS[0]`, and fall back to `fallbackSkin` if needed. 
- Changed file: `script.js` to guard accesses to skin properties used by `totalMultiplier()`.

### Testing
- Ran `node --check script.js` to validate syntax and the change passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998335227908330960e0cc7e43fcf47)