### PR TITLE
Guard against undefined skin entries to prevent multiplier crash

### DIFF
--- a/script.js
+++ b/script.js
@@ -427,9 +427,16 @@
     if (!SKINS || SKINS.length === 0) return fallbackSkin;
 
     for (var i = 0; i < SKINS.length; i++) {
-      if (SKINS[i].id === state.activeSkin) return SKINS[i];
+      var skin = SKINS[i];
+      if (!skin) continue;
+      if (skin.id === state.activeSkin) return skin;
     }
-    return SKINS[0] || fallbackSkin;
+
+    for (var j = 0; j < SKINS.length; j++) {
+      if (SKINS[j]) return SKINS[j];
+    }
+
+    return fallbackSkin;
   }
 
   function cps() {
@@ -451,7 +458,9 @@
       var owned = state.upgrades[up.id] || 0;
       if (up.mult) multiplier *= Math.pow(up.mult, owned);
     }
-    multiplier *= currentSkin().mult;
+    var skin = currentSkin();
+    var skinMultiplier = skin && typeof skin.mult === 'number' ? skin.mult : 1;
+    multiplier *= skinMultiplier;
     multiplier *= (1 + state.rebirths * 0.25);
     return multiplier;
   }


### PR DESCRIPTION
### Motivation
- The game was crashing with `TypeError: Cannot read properties of undefined (reading 'mult')` when `currentSkin()` returned `undefined` due to sparse or invalid entries in the `SKINS` array.
- The change aims to make skin lookup and multiplier calculation resilient to unexpected gaps or incomplete skin data so the game loop no longer throws repeatedly.

### Description
- Hardened `currentSkin()` to skip falsy `SKINS` entries and return the matching `state.activeSkin` only if the entry is valid, then return the first valid skin entry before falling back to a guaranteed `fallbackSkin` object.
- Made `totalMultiplier()` defensive by reading the skin multiplier via `var skin = currentSkin(); var skinMultiplier = skin && typeof skin.mult === 'number' ? skin.mult : 1;` so a missing or malformed `mult` defaults to `1`.
- These changes prevent attempts to read `.mult` from `undefined` without changing existing skin data structures or behavior when data is valid.

### Testing
- Ran `node --check script.js` which completed successfully and reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998343cfa10833083d1cd26a38e51ae)