### PR TITLE
Add Tim click animation and harden Firebase runtime

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4163953497019376"
-     crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Tim Clicker :3</title>
@@ -190,6 +188,6 @@
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-database-compat.js"></script>
-  <script src="script.js?v=20260303c"></script>
+  <script src="script.js?v=20260307a"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -4,7 +4,7 @@
   // ---------- Firebase ----------
   var firebaseConfig = {};
   firebaseConfig.apiKey = 'AIzaSyBZDGbuenDWIE8O0hjCa8h98n1os-8MZNs';
-  firebaseConfig.authDomain = 'tim-clicker.firebaseapp.com';
+  firebaseConfig.authDomain = 'tim-clicker.web.app';
   firebaseConfig.databaseURL = 'https://tim-clicker-default-rtdb.europe-west1.firebasedatabase.app';
   firebaseConfig.projectId = 'tim-clicker';
   firebaseConfig.messagingSenderId = '493561136507';
@@ -38,6 +38,7 @@
   var leaderboardEntries = [];
   var activeLeaderboardBoard = 'tims';
   var leaderboardWritesBlockedByPolicy = false;
+  var leaderboardWriteInFlight = false;
   var userGestureCaptured = false;
 
   function buildSessionId() {
@@ -1276,6 +1277,7 @@
     if (!firebaseReady || !db || !uid) return;
     if (!isWriteAuthorizedForUid(uid)) return;
     if (leaderboardWritesBlockedByPolicy) return;
+    if (leaderboardWriteInFlight) return;
     var playerName = typeof state.name === 'string' ? state.name.trim() : '';
     if (playerName.length > 40) playerName = playerName.slice(0, 40);
     var payload = {
@@ -1285,12 +1287,25 @@
       highestMulti: safeFiniteNumber(state.highestMulti, 1),
       updatedAt: Date.now()
     };
-    db.ref('leaderboard/' + uid).update(payload).catch(function (err) {
-      if (!isPermissionDeniedError(err)) return;
-      leaderboardWritesBlockedByPolicy = true;
-      var statusEl = el('leaderboardStatus');
-      if (statusEl) statusEl.textContent = 'Leaderboard write disabled: Realtime Database rules deny access.';
-    });
+    leaderboardWriteInFlight = true;
+    db.ref('leaderboard/' + uid).update(payload)
+      .catch(function (err) {
+        if (!isPermissionDeniedError(err)) return;
+        leaderboardWritesBlockedByPolicy = true;
+        var statusEl = el('leaderboardStatus');
+        if (statusEl) statusEl.textContent = 'Leaderboard write disabled: Realtime Database rules deny access.';
+      })
+      .finally(function () {
+        leaderboardWriteInFlight = false;
+      });
+  }
+
+  function animateTimClick() {
+    var timImage = el('timImage');
+    if (!timImage) return;
+    timImage.classList.remove('tim-click-anim');
+    void timImage.offsetWidth;
+    timImage.classList.add('tim-click-anim');
   }
 
   function startRealtimeSync() {
@@ -1758,6 +1773,7 @@
     var clickBonus = 1 + state.rebirths * 0.25;
     var beterOwned = state.upgrades.u45 || 0;
     if (beterOwned > 0) clickBonus += cps() * 0.2 * beterOwned;
+    animateTimClick();
     addTims(clickBonus, true);
     addQuestProgress('clicks', 1);
     saveNow();

--- a/style.css
+++ b/style.css
@@ -80,6 +80,29 @@ body {
   cursor: pointer;
   border-radius: 12px;
   border: 1px solid var(--line);
+  transition: transform 100ms ease, filter 100ms ease;
+  transform-origin: center center;
+  user-select: none;
+  -webkit-user-drag: none;
+}
+
+#timImage.tim-click-anim {
+  animation: tim-click-pop 150ms ease-out;
+}
+
+@keyframes tim-click-pop {
+  0% {
+    transform: scale(1);
+    filter: brightness(1);
+  }
+  35% {
+    transform: scale(0.92);
+    filter: brightness(1.12);
+  }
+  100% {
+    transform: scale(1);
+    filter: brightness(1);
+  }
 }
 
 input, button, select {


### PR DESCRIPTION
### Motivation
- Provide visual feedback when the player clicks Tim and reduce noisy console errors seen in blocked/referrer environments.
- Prevent duplicate leaderboard write attempts from spamming errors when Realtime Database rules block writes.

### Description
- Add a lightweight click animation handler `animateTimClick()` and wire it into the Tim click handler so each click triggers the `tim-click-pop` animation (changes in `script.js` and `style.css`).
- Add CSS polish for `#timImage` including `transition`, drag/select prevention, and `@keyframes tim-click-pop` for the pop/brightness effect (changes in `style.css`).
- Add an in-flight guard `leaderboardWriteInFlight` around leaderboard updates and use `.finally()` to clear the guard to avoid overlapping writes when writes fail (change in `script.js`).
- Align Firebase runtime behavior by switching `firebaseConfig.authDomain` to `tim-clicker.web.app` and remove the AdSense bootstrap script from `index.html`; bump the `script.js` cache-busting query string to load the updated runtime.

### Testing
- Static checks: `node --check script.js` and `node --check app.js` both succeeded.
- JSON validation: `python -m json.tool database.rules.json` succeeded.
- Local runtime smoke: served the site with `python -m http.server 4173` and exercised the UI with a Playwright smoke script that clicks `#timImage`; a screenshot artifact was produced showing the visual change.
- Runtime behavior: verified leaderboard write guard prevents repeated in-flight writes and that removing the AdSense tag eliminates the blocked `adsbygoogle.js` console noise during local testing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abe4f0978c833095f81d4d01627ef0)