### PR TITLE
Force Firebase RTDB long-polling fallback to avoid websocket internal errors

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,6 +17,13 @@
     if (window.firebase) {
       auth = firebase.auth();
       db = firebase.database();
+      if (
+        firebase.database &&
+        firebase.database.INTERNAL &&
+        typeof firebase.database.INTERNAL.forceLongPolling === 'function'
+      ) {
+        firebase.database.INTERNAL.forceLongPolling();
+      }
       firebaseReady = true;
     }
   } catch (err) {

--- a/script.js
+++ b/script.js
@@ -291,6 +291,13 @@
         if (window.firebase) {
           auth = firebase.auth();
           db = firebase.database();
+          if (
+            firebase.database &&
+            firebase.database.INTERNAL &&
+            typeof firebase.database.INTERNAL.forceLongPolling === 'function'
+          ) {
+            firebase.database.INTERNAL.forceLongPolling();
+          }
           auth.useDeviceLanguage();
           firebaseReady = true;
         }


### PR DESCRIPTION
### Motivation
- Intermittent `@firebase/database` websocket internal errors (e.g. "Error on incoming message") were observed in restrictive networks or behind proxies, causing realtime failures.
- Forcing the Firebase Realtime Database client to use long-polling can avoid those websocket transport issues in affected environments.
- The legacy runtime (`app.js`) must receive the same behavior so cached/older runtime loads behave consistently.

### Description
- Detects and calls `firebase.database.INTERNAL.forceLongPolling()` (when available) immediately after `db = firebase.database()` in `script.js` to enable long-polling fallback at initialization.
- Mirrors the same guarded call in the legacy shim `app.js` so both runtime paths use the fallback when the SDK exposes the hook.
- The call is feature-detected with `firebase.database && firebase.database.INTERNAL && typeof firebase.database.INTERNAL.forceLongPolling === 'function'` to avoid runtime errors on SDKs that don't expose the hook.
- Changes are scoped to initialization and do not alter other runtime logic or Firebase configuration.

### Testing
- Ran `node --check script.js` and `node --check app.js` to validate the modified files parse as valid JavaScript, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aed2a8cc2c833094e7df25783c72ce)